### PR TITLE
Add web UI service to Docker Compose and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ An AI-powered tool that automatically organizes your photos into Instagram-ready
 
    All command-line arguments supported by `ai_instagram_organizer.py` can be passed this way.
 
+### 🖥️ Run the Web Dashboard with Docker
+
+The Compose file also includes a `webui` service that launches the FastAPI dashboard. It reuses the same environment variables
+and volume mounts as the CLI container, so your API keys and mounted photo/config directories are available to the UI.
+
+1. **Start the dashboard**:
+
+   ```bash
+   docker compose up webui
+   ```
+
+2. **Open the app** at [http://localhost:8000](http://localhost:8000). The container publishes port `8000` so the FastAPI UI is
+   reachable from your browser.
+
+3. **Customize paths if needed** by exporting `HOST_PHOTO_DIR` and `HOST_CONFIG_FILE` before running Compose. The same values
+   used for the CLI are shared with the dashboard.
+
 ### Prerequisites
 
 1. **Install Python dependencies**:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,17 @@ services:
       - ${HOST_PHOTO_DIR:-./photos}:/data/photos
       - ${HOST_CONFIG_FILE:-./config_example.json}:/app/config.json:ro
     command: ["--source", "/data/photos", "--dev-mode", "--limit", "5"]
+
+  webui:
+    build:
+      context: .
+    image: ai-instagram-organizer:latest
+    environment:
+      LLAMA_API_KEY: ${LLAMA_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+    volumes:
+      - ${HOST_PHOTO_DIR:-./photos}:/data/photos
+      - ${HOST_CONFIG_FILE:-./config_example.json}:/app/config.json:ro
+    ports:
+      - "8000:8000"
+    entrypoint: ["python", "webui/server.py"]


### PR DESCRIPTION
## Summary
- add a `webui` service to docker-compose that launches the FastAPI dashboard on port 8000 while reusing the existing environment variables and volumes
- document how to start the web UI via Docker Compose and how it shares API keys and mounted paths with the CLI container

## Testing
- not run (configuration and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cee81f4d4c832798e9ce9be59b9965